### PR TITLE
issue-14 Allow specification of docker registry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+helm-values/
+kubernetes/

--- a/docs/helm-kafka-db2/README.md
+++ b/docs/helm-kafka-db2/README.md
@@ -156,7 +156,7 @@ The Git repository has files that will be used in the `helm install --values` pa
     export DEMO_PREFIX=my
     export DEMO_NAMESPACE=${DEMO_PREFIX}-namespace
 
-    export DOCKER_REGISTRY_URL=my.docker-registry.com:5000
+    export DOCKER_REGISTRY_URL=docker.io
     ```
 
 1. Set environment variables listed in "[Clone repository](#clone-repository)".

--- a/docs/helm-kafka-postgresql/README.md
+++ b/docs/helm-kafka-postgresql/README.md
@@ -379,7 +379,7 @@ This deployment will be used later to:
       --name ${DEMO_PREFIX}-stable \
       --namespace ${DEMO_NAMESPACE} \
       --values ${HELM_VALUES_DIR}/postgresql.yaml \
-      bitnami/postgresql
+      stable/postgresql
     ```
 
 1. Wait for pod to run.  Example:

--- a/docs/helm-kafka-postgresql/README.md
+++ b/docs/helm-kafka-postgresql/README.md
@@ -157,7 +157,7 @@ The Git repository has files that will be used in the `helm install --values` pa
     export DEMO_PREFIX=my
     export DEMO_NAMESPACE=${DEMO_PREFIX}-namespace
 
-    export DOCKER_REGISTRY_URL=my.docker-registry.com:5000
+    export DOCKER_REGISTRY_URL=docker.io
     ```
 
 1. Set environment variables listed in "[Clone repository](#clone-repository)".

--- a/docs/helm-kafka-postgresql/README.md
+++ b/docs/helm-kafka-postgresql/README.md
@@ -237,14 +237,12 @@ The Git repository has files that will be used in the `helm install --values` pa
 1. Create persistent volumes.  Example:
 
     ```console
-    kubectl create -f ${KUBERNETES_DIR}/persistent-volume-postgresql.yaml
     kubectl create -f ${KUBERNETES_DIR}/persistent-volume-opt-senzing.yaml
     ```
 
 1. Create persistent volume claims.  Example:
 
     ```console
-    kubectl create -f ${KUBERNETES_DIR}/persistent-volume-claim-postgresql.yaml
     kubectl create -f ${KUBERNETES_DIR}/persistent-volume-claim-opt-senzing.yaml
     ```
 
@@ -378,7 +376,7 @@ This deployment will be used later to:
 
     ```console
     helm install \
-      --name ${DEMO_PREFIX}-postgresql \
+      --name ${DEMO_PREFIX}-stable \
       --namespace ${DEMO_NAMESPACE} \
       --values ${HELM_VALUES_DIR}/postgresql.yaml \
       bitnami/postgresql

--- a/docs/helm-kafka-postgresql/README.md
+++ b/docs/helm-kafka-postgresql/README.md
@@ -376,7 +376,7 @@ This deployment will be used later to:
 
     ```console
     helm install \
-      --name ${DEMO_PREFIX}-stable \
+      --name ${DEMO_PREFIX}-postgresql \
       --namespace ${DEMO_NAMESPACE} \
       --values ${HELM_VALUES_DIR}/postgresql.yaml \
       stable/postgresql

--- a/docs/helm-rabbitmq-db2/README.md
+++ b/docs/helm-rabbitmq-db2/README.md
@@ -155,7 +155,7 @@ The Git repository has files that will be used in the `helm install --values` pa
     export DEMO_PREFIX=my
     export DEMO_NAMESPACE=${DEMO_PREFIX}-namespace
 
-    export DOCKER_REGISTRY_URL=my.docker-registry.com:5000
+    export DOCKER_REGISTRY_URL=docker.io
     ```
 
 1. Set environment variables listed in "[Clone repository](#clone-repository)".

--- a/docs/helm-rabbitmq-db2/README.md
+++ b/docs/helm-rabbitmq-db2/README.md
@@ -256,12 +256,6 @@ The Git repository has files that will be used in the `helm install --values` pa
 
 ### Add helm repositories
 
-1. Add Bitnami repository.  Example:
-
-    ```console
-    helm repo add bitnami https://charts.bitnami.com
-    ```
-
 1. Add Senzing repository.  Example:
 
     ```console
@@ -432,7 +426,7 @@ This step creates tables in the database used by Senzing.
       --name ${DEMO_PREFIX}-rabbitmq \
       --namespace ${DEMO_NAMESPACE} \
       --values ${HELM_VALUES_DIR}/rabbitmq.yaml \
-      bitnami/rabbitmq
+      stable/rabbitmq
     ```
 
 1. In a separate terminal window, port forward to local machine.
@@ -553,7 +547,6 @@ See `kubectl port-forward ...` above.
     helm delete --purge ${DEMO_PREFIX}-senzing-debug
     helm delete --purge ${DEMO_PREFIX}-senzing-package
     helm repo remove senzing
-    helm repo remove bitnami
     kubectl delete -f ${KUBERNETES_DIR}/persistent-volume-claim-opt-senzing.yaml
     kubectl delete -f ${KUBERNETES_DIR}/persistent-volume-opt-senzing.yaml
     kubectl delete -f ${KUBERNETES_DIR}/namespace.yaml

--- a/docs/helm-rabbitmq-postgresql/README.md
+++ b/docs/helm-rabbitmq-postgresql/README.md
@@ -156,7 +156,7 @@ The Git repository has files that will be used in the `helm install --values` pa
     export DEMO_PREFIX=my
     export DEMO_NAMESPACE=${DEMO_PREFIX}-namespace
 
-    export DOCKER_REGISTRY_URL=my.docker-registry.com:5000
+    export DOCKER_REGISTRY_URL=docker.io
     ```
 
 1. Set environment variables listed in "[Clone repository](#clone-repository)".

--- a/docs/helm-rabbitmq-postgresql/README.md
+++ b/docs/helm-rabbitmq-postgresql/README.md
@@ -236,14 +236,12 @@ The Git repository has files that will be used in the `helm install --values` pa
 1. Create persistent volumes.  Example:
 
     ```console
-    kubectl create -f ${KUBERNETES_DIR}/persistent-volume-postgresql.yaml
     kubectl create -f ${KUBERNETES_DIR}/persistent-volume-opt-senzing.yaml
     ```
 
 1. Create persistent volume claims.  Example:
 
     ```console
-    kubectl create -f ${KUBERNETES_DIR}/persistent-volume-claim-postgresql.yaml
     kubectl create -f ${KUBERNETES_DIR}/persistent-volume-claim-opt-senzing.yaml
     ```
 

--- a/docs/helm-rabbitmq-postgresql/README.md
+++ b/docs/helm-rabbitmq-postgresql/README.md
@@ -259,12 +259,6 @@ The Git repository has files that will be used in the `helm install --values` pa
 
 ### Add helm repositories
 
-1. Add Bitnami repository.  Example:
-
-    ```console
-    helm repo add bitnami https://charts.bitnami.com
-    ```
-
 1. Add Senzing repository.  Example:
 
     ```console
@@ -380,7 +374,7 @@ This deployment will be used later to:
       --name ${DEMO_PREFIX}-postgresql \
       --namespace ${DEMO_NAMESPACE} \
       --values ${HELM_VALUES_DIR}/postgresql.yaml \
-      bitnami/postgresql
+      stable/postgresql
     ```
 
 1. Wait for pod to run.  Example:
@@ -461,7 +455,7 @@ This step creates tables in the database used by Senzing.
       --name ${DEMO_PREFIX}-rabbitmq \
       --namespace ${DEMO_NAMESPACE} \
       --values ${HELM_VALUES_DIR}/rabbitmq.yaml \
-      bitnami/rabbitmq
+      stable/rabbitmq
     ```
 
 1. In a separate terminal window, port forward to local machine.
@@ -584,7 +578,6 @@ See `kubectl port-forward ...` above.
     helm delete --purge ${DEMO_PREFIX}-senzing-debug
     helm delete --purge ${DEMO_PREFIX}-senzing-package
     helm repo remove senzing
-    helm repo remove bitnami
     kubectl delete -f ${KUBERNETES_DIR}/persistent-volume-claim-opt-senzing.yaml
     kubectl delete -f ${KUBERNETES_DIR}/persistent-volume-claim-postgresql.yaml
     kubectl delete -f ${KUBERNETES_DIR}/persistent-volume-opt-senzing.yaml

--- a/helm-values-templates/db2-client.yaml
+++ b/helm-values-templates/db2-client.yaml
@@ -1,3 +1,6 @@
+image:
+  registry: ${DOCKER_REGISTRY_URL}
+
 db2:
   password: db2inst1
   optSenzingStorageClaim: opt-senzing-claim

--- a/helm-values-templates/hello-world.yaml
+++ b/helm-values-templates/hello-world.yaml
@@ -1,6 +1,7 @@
 image:
-  repository: "${DOCKER_REGISTRY_URL}/senzing/hello-world"
-  tag: "latest"
+  registry: ${DOCKER_REGISTRY_URL}
+  repository: senzing/hello-world
+  tag: latest
 
 senzing:
   sleepTime: 60

--- a/helm-values-templates/ibm-db2express-c.yaml
+++ b/helm-values-templates/ibm-db2express-c.yaml
@@ -1,6 +1,9 @@
+image:
+  registry: ${DOCKER_REGISTRY_URL}
+
 db2:
   license: accept
   password: db2inst1
 
-senzing:  
+senzing:
   optSenzingStorageClaim: opt-senzing-claim

--- a/helm-values-templates/kafka-test-client.yaml
+++ b/helm-values-templates/kafka-test-client.yaml
@@ -1,0 +1,2 @@
+image:
+  registry: ${DOCKER_REGISTRY_URL}

--- a/helm-values-templates/mock-data-generator-kafka.yaml
+++ b/helm-values-templates/mock-data-generator-kafka.yaml
@@ -1,3 +1,6 @@
+image:
+  registry: ${DOCKER_REGISTRY_URL}
+
 senzing:
   subcommand: "url-to-kafka"
   kafkaBootstrapServerHost: "${DEMO_PREFIX}-kafka"

--- a/helm-values-templates/mock-data-generator-rabbitmq.yaml
+++ b/helm-values-templates/mock-data-generator-rabbitmq.yaml
@@ -1,3 +1,6 @@
+image:
+  registry: ${DOCKER_REGISTRY_URL}
+
 senzing:
   subcommand: url-to-rabbitmq
   rabbitmqHost: ${DEMO_PREFIX}-rabbitmq

--- a/helm-values-templates/mysql-client.yaml
+++ b/helm-values-templates/mysql-client.yaml
@@ -1,3 +1,6 @@
+image:
+  registry: ${DOCKER_REGISTRY_URL}
+
 mysql:
   database: "G2"
   file: "g2/data/g2core-schema-mysql-create.sql"

--- a/helm-values-templates/phpmyadmin.yaml
+++ b/helm-values-templates/phpmyadmin.yaml
@@ -1,3 +1,6 @@
+image:
+  registry: ${DOCKER_REGISTRY_URL}
+
 db:
   host: "${DEMO_PREFIX}-mysql-mysql"
 

--- a/helm-values-templates/phppgadmin.yaml
+++ b/helm-values-templates/phppgadmin.yaml
@@ -1,3 +1,6 @@
+image:
+  registry: ${DOCKER_REGISTRY_URL}
+
 ingress:
   enabled: true
 

--- a/helm-values-templates/postgresql-client.yaml
+++ b/helm-values-templates/postgresql-client.yaml
@@ -1,3 +1,6 @@
+image:
+  registry: ${DOCKER_REGISTRY_URL}
+
 postgresql:
   database: G2
   file: g2/data/g2core-schema-postgresql-create.sql

--- a/helm-values-templates/postgresql.yaml
+++ b/helm-values-templates/postgresql.yaml
@@ -1,9 +1,9 @@
 persistence:
-  existingClaim: postgresql-claim
+  enabled: false
+# existingClaim: postgresql-claim
 
 postgresqlDatabase: G2
 postgresqlPassword: postgres
 
 securityContext:
   enabled: false
-

--- a/helm-values-templates/postgresql.yaml
+++ b/helm-values-templates/postgresql.yaml
@@ -1,6 +1,3 @@
-image:
-  pullPolicy: Always
-
 persistence:
   existingClaim: postgresql-claim
 

--- a/helm-values-templates/senzing-api-server-db2.yaml
+++ b/helm-values-templates/senzing-api-server-db2.yaml
@@ -1,3 +1,6 @@
+image:
+  registry: ${DOCKER_REGISTRY_URL}
+
 senzing:
   bindAddr: "all"
   concurrency: 8

--- a/helm-values-templates/senzing-api-server-mysql.yaml
+++ b/helm-values-templates/senzing-api-server-mysql.yaml
@@ -1,3 +1,6 @@
+image:
+  registry: ${DOCKER_REGISTRY_URL}
+
 senzing:
   bindAddr: "all"
   concurrency: 8

--- a/helm-values-templates/senzing-api-server-postgresql.yaml
+++ b/helm-values-templates/senzing-api-server-postgresql.yaml
@@ -1,3 +1,6 @@
+image:
+  registry: ${DOCKER_REGISTRY_URL}
+
 senzing:
   bindAddr: "all"
   concurrency: 8

--- a/helm-values-templates/senzing-debug-db2.yaml
+++ b/helm-values-templates/senzing-debug-db2.yaml
@@ -1,3 +1,6 @@
+image:
+  registry: ${DOCKER_REGISTRY_URL}
+
 senzing:
   databaseUrl: "db2://db2inst1:db2inst1@${DEMO_PREFIX}-ibm-db2express-c:50000/G2"
   optSenzingClaim: opt-senzing-claim

--- a/helm-values-templates/senzing-debug-mysql.yaml
+++ b/helm-values-templates/senzing-debug-mysql.yaml
@@ -1,3 +1,6 @@
+image:
+  registry: ${DOCKER_REGISTRY_URL}
+
 senzing:
   databaseUrl: "mysql://g2:g2@${DEMO_PREFIX}-mysql-mysql:3306/G2"
   optSenzingClaim: opt-senzing-claim

--- a/helm-values-templates/senzing-debug-postgresql.yaml
+++ b/helm-values-templates/senzing-debug-postgresql.yaml
@@ -1,3 +1,6 @@
+image:
+  registry: ${DOCKER_REGISTRY_URL}
+
 senzing:
   databaseUrl: "postgresql://postgres:postgres@${DEMO_PREFIX}-postgresql-postgresql:5432/G2"
   optSenzingClaim: opt-senzing-claim

--- a/helm-values-templates/senzing-package-sleep.yaml
+++ b/helm-values-templates/senzing-package-sleep.yaml
@@ -1,7 +1,6 @@
 image:
   registry: ${DOCKER_REGISTRY_URL}
   repository: senzing/senzing-package
-  tag: latest
 
 senzing:
   subcommand: sleep

--- a/helm-values-templates/senzing-package-sleep.yaml
+++ b/helm-values-templates/senzing-package-sleep.yaml
@@ -1,5 +1,6 @@
 image:
-  repository: "${DOCKER_REGISTRY_URL}/senzing/senzing-package"
+  registry: ${DOCKER_REGISTRY_URL}
+  repository: senzing/senzing-package
   tag: latest
 
 senzing:

--- a/helm-values-templates/senzing-package.yaml
+++ b/helm-values-templates/senzing-package.yaml
@@ -1,8 +1,6 @@
 image:
   registry: ${DOCKER_REGISTRY_URL}
   repository: senzing/senzing-package
-  tag: latest
-  pullPolicy: Always
 
 senzing:
   subcommand: install

--- a/helm-values-templates/senzing-package.yaml
+++ b/helm-values-templates/senzing-package.yaml
@@ -1,5 +1,6 @@
 image:
-  repository: "${DOCKER_REGISTRY_URL}/senzing/senzing-package"
+  registry: ${DOCKER_REGISTRY_URL}
+  repository: senzing/senzing-package
   tag: latest
   pullPolicy: Always
 

--- a/helm-values-templates/stream-loader-kafka-db2.yaml
+++ b/helm-values-templates/stream-loader-kafka-db2.yaml
@@ -1,3 +1,6 @@
+image:
+  registry: ${DOCKER_REGISTRY_URL}
+
 senzing:
   subcommand: kafka
   databaseUrl: "db2://db2inst1:db2inst1@${DEMO_PREFIX}-ibm-db2express-c:50000/G2"

--- a/helm-values-templates/stream-loader-kafka-mysql.yaml
+++ b/helm-values-templates/stream-loader-kafka-mysql.yaml
@@ -1,3 +1,6 @@
+image:
+  registry: ${DOCKER_REGISTRY_URL}
+
 senzing:
   subcommand: kafka
   databaseUrl: "mysql://g2:g2@${DEMO_PREFIX}-mysql-mysql:3306/G2"

--- a/helm-values-templates/stream-loader-kafka-postgresql.yaml
+++ b/helm-values-templates/stream-loader-kafka-postgresql.yaml
@@ -1,3 +1,6 @@
+image:
+  registry: ${DOCKER_REGISTRY_URL}
+
 senzing:
   subcommand: kafka
   databaseUrl: "postgresql://postgres:postgres@${DEMO_PREFIX}-postgresql-postgresql:5432/G2"

--- a/helm-values-templates/stream-loader-rabbitmq-db2.yaml
+++ b/helm-values-templates/stream-loader-rabbitmq-db2.yaml
@@ -1,3 +1,6 @@
+image:
+  registry: ${DOCKER_REGISTRY_URL}
+
 senzing:
   subcommand: rabbitmq
   databaseUrl: "db2://db2inst1:db2inst1@${DEMO_PREFIX}-ibm-db2express-c:50000/G2"

--- a/helm-values-templates/stream-loader-rabbitmq-mysql.yaml
+++ b/helm-values-templates/stream-loader-rabbitmq-mysql.yaml
@@ -1,3 +1,9 @@
+image:
+  registry: ${DOCKER_REGISTRY_URL}
+  repository: senzing/xxx
+  tag: latest
+  pullPolicy: Always
+
 senzing:
   subcommand: rabbitmq
   databaseUrl: "mysql://g2:g2@${DEMO_PREFIX}-mysql-mysql:3306/G2"

--- a/helm-values-templates/stream-loader-rabbitmq-mysql.yaml
+++ b/helm-values-templates/stream-loader-rabbitmq-mysql.yaml
@@ -1,8 +1,5 @@
 image:
   registry: ${DOCKER_REGISTRY_URL}
-  repository: senzing/xxx
-  tag: latest
-  pullPolicy: Always
 
 senzing:
   subcommand: rabbitmq

--- a/helm-values-templates/stream-loader-rabbitmq-postgresql.yaml
+++ b/helm-values-templates/stream-loader-rabbitmq-postgresql.yaml
@@ -1,3 +1,9 @@
+image:
+  registry: ${DOCKER_REGISTRY_URL}
+  repository: senzing/xxx
+  tag: latest
+  pullPolicy: Always
+
 senzing:
   subcommand: rabbitmq
   databaseUrl: "postgresql://postgres:postgres@${DEMO_PREFIX}-postgresql-postgresql:5432/G2"

--- a/helm-values-templates/stream-loader-rabbitmq-postgresql.yaml
+++ b/helm-values-templates/stream-loader-rabbitmq-postgresql.yaml
@@ -1,8 +1,5 @@
 image:
   registry: ${DOCKER_REGISTRY_URL}
-  repository: senzing/xxx
-  tag: latest
-  pullPolicy: Always
 
 senzing:
   subcommand: rabbitmq


### PR DESCRIPTION
# Pull request questions

## Which issue does this address

ISSUE-14
## Why was change needed

The use of only `docker.io` docker registry is too rigid.

## What does change improve

This allows a user to specify a local private repository.
